### PR TITLE
[bugfix] Do not change annotation groups on document update

### DIFF
--- a/src/components/DocumentForm/DocumentForm.js
+++ b/src/components/DocumentForm/DocumentForm.js
@@ -266,9 +266,11 @@ const DocumentForm = ({
       },
     });
     if (res.status === 200) {
-      await res.json();
+      const result = await res.json();
       const documentToUpdate = { ...valuesWithSerializedText, slug };
-      return Promise.resolve(await updateAllAnnotationsOnDocument(documentToUpdate));
+      if (valuesWithSerializedText.state === 'draft') {
+        return Promise.resolve(result);
+      } return Promise.resolve(await updateAllAnnotationsOnDocument(documentToUpdate));
     }
     return Promise.reject(Error(`Unable to edit document: error ${res.status} received from server`));
   };

--- a/src/pages/api/annotations.js
+++ b/src/pages/api/annotations.js
@@ -99,9 +99,6 @@ const handler = async (req, res) => {
           findCondition = { 'target.document.slug': documentToUpdate.slug };
         }
         if (!documentToUpdate.format) documentToUpdate.format = 'text/html';
-        const { groups } = userObj;
-        const userGroups = groups.map((group) => group.id);
-        const groupIntersection = documentToUpdate.groups.filter((id) => userGroups.includes(id));
         const arr = await db
           .collection('annotations')
           .updateMany(
@@ -109,7 +106,6 @@ const handler = async (req, res) => {
             {
               $set: {
                 'target.document': documentToUpdate,
-                'permissions.groups': groupIntersection,
               },
               $currentDate: { modified: true },
             },


### PR DESCRIPTION
Also, only annotations on non-draft documents will attempt to update.